### PR TITLE
chore(automation): switch content update workflow to weekly

### DIFF
--- a/.github/workflows/daily-content-update.yml
+++ b/.github/workflows/daily-content-update.yml
@@ -2,8 +2,8 @@ name: Daily Content Update
 
 on:
   schedule:
-    # Run daily at 8:00 AM UTC
-    - cron: '0 8 * * *'
+    # Run weekly on Monday at 8:00 AM UTC
+    - cron: '0 8 * * 1'
   workflow_dispatch: # Allow manual trigger
 
 permissions:


### PR DESCRIPTION
## Summary
- Switch the content update workflow cron from daily (`0 8 * * *`) to weekly Monday 08:00 UTC (`0 8 * * 1`).
- Aim is to reduce PR noise — 38 daily status PRs had accumulated unmerged before this change.

## Test plan
- [ ] Confirm next scheduled run lands on the upcoming Monday at 08:00 UTC
- [ ] `workflow_dispatch` manual trigger still works if an off-schedule run is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)